### PR TITLE
fix index page bug

### DIFF
--- a/catalog/examples/bindels_gietema.qmd
+++ b/catalog/examples/bindels_gietema.qmd
@@ -1,5 +1,5 @@
 ---
-title: "4. Edzo Bindels, Ruurd Gietema, Henk Hartzema, Arjan Klok"
+title: "4, Edzo Bindels, Ruurd Gietema, Henk Hartzema, Arjan Klok"
 author: "Rotterdam-Maaskant Foundation"
 description: "A plan reinterpreting the typical modernist features of a post war housing area"
 categories: [the use of 3d, Amsterdam, Edzo Bindels, comparison, conceptual abstraction, “French school” of analysis, Casper van der Hoeven, “Italian school” of analysis, morphological layers, Jos Louwe, modern cities, plan analysis, visualisation, map based, data based, type, form, space, composition]


### PR DESCRIPTION
<img width="1618" height="1376" alt="image" src="https://github.com/user-attachments/assets/17beff11-36a0-4087-a743-a0be01c2b105" />

after chaning the dot into comma in the title, the index page can be rendered normally now